### PR TITLE
deploy foo app and fix bar namespace issue

### DIFF
--- a/kind-goodnotes-k8s-demo/apps/bar/deployment-config.yaml
+++ b/kind-goodnotes-k8s-demo/apps/bar/deployment-config.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bar
+  namespace: apps
   labels: { app: http-echo, variant: bar }
 spec:
   replicas: 2

--- a/kind-goodnotes-k8s-demo/apps/foo/deployment-config.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/deployment-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  namespace: apps
+  labels: { app: http-echo, variant: foo }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: http-echo, variant: foo } }
+  template:
+    metadata:
+      labels: { app: http-echo, variant: foo }
+    spec:
+      containers:
+        - name: echo
+          image: hashicorp/http-echo:1.0.0
+          args: ["-text=foo", "-listen=:5678"]
+          ports:
+            - containerPort: 5678
+          readinessProbe:
+            httpGet: { path: "/", port: 5678 }
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests: { cpu: "10m", memory: "16Mi" }
+            limits:   { cpu: "200m", memory: "64Mi" }

--- a/kind-goodnotes-k8s-demo/apps/foo/ingress.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: foo
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foo.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: foo
+                port: { number: 80 }

--- a/kind-goodnotes-k8s-demo/apps/foo/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployment-config.yaml
+- service.yaml
+- ingress.yaml

--- a/kind-goodnotes-k8s-demo/apps/foo/service.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+spec:
+  selector: { app: http-echo, variant: foo }
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 5678


### PR DESCRIPTION
`bar` urgent fixed applied


`foo` kubectl diff
```diff
➜  DevOps-Kubernetes-GoodNotes git:(main-deploy-foo-apps-and-fix-bar-namespace-issue) ✗ k diff -k kind-goodnotes-k8s-demo/apps/foo                                    
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/apps.v1.Deployment.apps.foo /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/apps.v1.Deployment.apps.foo
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/apps.v1.Deployment.apps.foo        2025-09-04 12:13:31
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/apps.v1.Deployment.apps.foo      2025-09-04 12:13:31
@@ -0,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: "2025-09-04T04:13:31Z"
+  generation: 1
+  labels:
+    app: http-echo
+    variant: foo
+  name: foo
+  namespace: apps
+  uid: ed232111-6005-42a4-8a89-e7609b7f694a
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: http-echo
+      variant: foo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: http-echo
+        variant: foo
+    spec:
+      containers:
+      - args:
+        - -text=foo
+        - -listen=:5678
+        image: hashicorp/http-echo:1.0.0
+        imagePullPolicy: IfNotPresent
+        name: echo
+        ports:
+        - containerPort: 5678
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 5678
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/networking.k8s.io.v1.Ingress.default.foo /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/networking.k8s.io.v1.Ingress.default.foo
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/networking.k8s.io.v1.Ingress.default.foo   2025-09-04 12:13:31
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/networking.k8s.io.v1.Ingress.default.foo 2025-09-04 12:13:31
@@ -0,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  creationTimestamp: "2025-09-04T04:13:31Z"
+  generation: 1
+  name: foo
+  namespace: default
+  uid: be2147ed-e0a0-4ba2-b99e-f56994317af8
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: foo.localhost
+    http:
+      paths:
+      - backend:
+          service:
+            name: foo
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+status:
+  loadBalancer: {}
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/v1.Service.default.foo /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/v1.Service.default.foo
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-4138787396/v1.Service.default.foo     2025-09-04 12:13:31
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-2187232110/v1.Service.default.foo   2025-09-04 12:13:31
@@ -0,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2025-09-04T04:13:31Z"
+  name: foo
+  namespace: default
+  uid: 9c9bc3e9-6f14-4a4e-b740-db816e0770c5
+spec:
+  clusterIP: 10.96.0.0
+  clusterIPs:
+  - 10.96.0.0
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 5678
+  selector:
+    app: http-echo
+    variant: foo
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
➜  DevOps-Kubernetes-GoodNotes git:(main-deploy-foo-apps-and-fix-bar-namespace-issue) ✗ 
``` 