### PR TITLE
update service namespace and clean env for ci loadtest

### DIFF
--- a/kind-goodnotes-k8s-demo/apps/bar/deployment-config.yaml
+++ b/kind-goodnotes-k8s-demo/apps/bar/deployment-config.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels: { app: http-echo, variant: bar }
     spec:
-      shareProcessNamespace: true
+      # shareProcessNamespace: true
       containers:
         - name: echo
           image: hashicorp/http-echo:1.0.0
@@ -25,11 +25,11 @@ spec:
           resources:
             requests: { cpu: "10m", memory: "16Mi" }
             limits:   { cpu: "200m", memory: "64Mi" }
-        - name: debug
-          image: radial/busyboxplus:curl
-          command: ["sh", "-c", "sleep infinity"]
-          stdin: true
-          tty: true
-          resources:
-            requests: { cpu: "5m", memory: "8Mi" }
-            limits:   { cpu: "50m", memory: "64Mi" }
+        # - name: debug
+        #   image: radial/busyboxplus:curl
+        #   command: ["sh", "-c", "sleep infinity"]
+        #   stdin: true
+        #   tty: true
+        #   resources:
+        #     requests: { cpu: "5m", memory: "8Mi" }
+        #     limits:   { cpu: "50m", memory: "64Mi" }

--- a/kind-goodnotes-k8s-demo/apps/bar/ingress.yaml
+++ b/kind-goodnotes-k8s-demo/apps/bar/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echo
+  namespace: apps
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/kind-goodnotes-k8s-demo/apps/bar/service.yaml
+++ b/kind-goodnotes-k8s-demo/apps/bar/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: bar
+  namespace: apps
 spec:
   selector: { app: http-echo, variant: bar }
   type: ClusterIP

--- a/kind-goodnotes-k8s-demo/apps/foo/service.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: foo
+  namespace: apps
 spec:
   selector: { app: http-echo, variant: foo }
   type: ClusterIP


### PR DESCRIPTION

clean current env for preparing auto ci load test.  the ci will cover app deployments and ingress rules config.

```sh
➜  apps git:(main-update-namespace-for-service-and-clean-env) ✗ kubectl delete all --all -n apps
pod "bar-5d84b94647-cs2gx" deleted
pod "bar-5d84b94647-pbnlf" deleted
pod "foo-6b55bdf-bbscq" deleted
pod "foo-6b55bdf-xmp9d" deleted
service "foo" deleted
deployment.apps "bar" deleted
deployment.apps "foo" deleted
➜  apps git:(main-update-namespace-for-service-and-clean-env) ✗
```