### PR TITLE
update ingress config for fixing issue

### DIFF
--- a/kind-goodnotes-k8s-demo/apps/bar/ingress.yaml
+++ b/kind-goodnotes-k8s-demo/apps/bar/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: echo
+  name: bar
   namespace: apps
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -16,4 +16,5 @@ spec:
             backend:
               service:
                 name: bar
-                port: { number: 80 }
+                port:
+                  name: http

--- a/kind-goodnotes-k8s-demo/apps/foo/ingress.yaml
+++ b/kind-goodnotes-k8s-demo/apps/foo/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo
+  namespace: apps
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
@@ -15,4 +16,5 @@ spec:
             backend:
               service:
                 name: foo
-                port: { number: 80 }
+                port:
+                  name: http

--- a/kind-goodnotes-k8s-demo/ingress-controller/controller.yaml
+++ b/kind-goodnotes-k8s-demo/ingress-controller/controller.yaml
@@ -506,6 +506,7 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+        ingress-ready: "true"
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
       tolerations:

--- a/kind-goodnotes-k8s-demo/ingress-controller/controller.yaml
+++ b/kind-goodnotes-k8s-demo/ingress-controller/controller.yaml
@@ -15,11 +15,12 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -27,7 +28,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -39,7 +40,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -129,7 +130,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -148,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -230,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -249,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -269,7 +270,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -288,7 +289,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -307,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -319,8 +320,7 @@ subjects:
   namespace: ingress-nginx
 ---
 apiVersion: v1
-data:
-  allow-snippet-annotations: "false"
+data: null
 kind: ConfigMap
 metadata:
   labels:
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -340,11 +340,10 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -373,7 +372,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -396,7 +395,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -418,12 +417,11 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.10.1
+        app.kubernetes.io/version: 1.12.1
     spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-nginx-leader
         - --controller-class=k8s.io/ingress-nginx
         - --ingress-class=nginx
@@ -431,7 +429,8 @@ spec:
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
-        - --enable-metrics=false
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
         env:
         - name: POD_NAME
           valueFrom:
@@ -443,7 +442,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: registry.k8s.io/ingress-nginx/controller:v1.10.1@sha256:e24f39d3eed6bcc239a56f20098878845f62baa34b9f2be2fd2c38ce9fb0f29e
+        image: registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:9724476b928967173d501040631b23ba07f47073999e80e34b120e8db5f234d5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -463,17 +462,15 @@ spec:
         name: controller
         ports:
         - containerPort: 80
+          hostPort: 80
           name: http
           protocol: TCP
         - containerPort: 443
+          hostPort: 443
           name: https
           protocol: TCP
         - containerPort: 8443
           name: webhook
-          protocol: TCP
-        - containerPort: 3100
-          hostPort: 3100
-          name: loki
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
@@ -497,6 +494,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: false
+          runAsGroup: 82
           runAsNonRoot: true
           runAsUser: 101
           seccompProfile:
@@ -509,7 +507,14 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Equal
       volumes:
       - name: webhook-cert
         secret:
@@ -523,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -534,7 +539,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.10.1
+        app.kubernetes.io/version: 1.12.1
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -548,7 +553,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1@sha256:36d05b4077fb8e3d13663702fa337f124675ba8667cbd949c03a8e8ea6fa4366
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4@sha256:a9f03b34a3cbfbb26d103a14046ab2c5130a80c3d69d526ff8063d2b37b9fd3f
         imagePullPolicy: IfNotPresent
         name: create
         securityContext:
@@ -557,6 +562,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
           seccompProfile:
@@ -574,7 +580,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -585,7 +591,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.10.1
+        app.kubernetes.io/version: 1.12.1
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -601,7 +607,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1@sha256:36d05b4077fb8e3d13663702fa337f124675ba8667cbd949c03a8e8ea6fa4366
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4@sha256:a9f03b34a3cbfbb26d103a14046ab2c5130a80c3d69d526ff8063d2b37b9fd3f
         imagePullPolicy: IfNotPresent
         name: patch
         securityContext:
@@ -610,6 +616,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
           seccompProfile:
@@ -627,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -640,7 +647,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.10.1
+    app.kubernetes.io/version: 1.12.1
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:
@@ -650,6 +657,7 @@ webhooks:
       name: ingress-nginx-controller-admission
       namespace: ingress-nginx
       path: /networking/v1/ingresses
+      port: 443
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validate.nginx.ingress.kubernetes.io


### PR DESCRIPTION


```diff
➜  DevOps-Kubernetes-GoodNotes git:(main-udpate-ingress-config) ✗ k diff -k kind-goodnotes-k8s-demo/apps/bar/
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-2297822551/networking.k8s.io.v1.Ingress.apps.bar /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-3595201157/networking.k8s.io.v1.Ingress.apps.bar
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-2297822551/networking.k8s.io.v1.Ingress.apps.bar      2025-09-05 12:23:15
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-3595201157/networking.k8s.io.v1.Ingress.apps.bar    2025-09-05 12:23:15
@@ -6,7 +6,7 @@
       {"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"nginx"},"name":"bar","namespace":"apps"},"spec":{"ingressClassName":"nginx","rules":[{"host":"bar.localhost","http":{"paths":[{"backend":{"service":{"name":"http","port":{"number":80}}},"path":"/","pathType":"Prefix"}]}}]}}
     kubernetes.io/ingress.class: nginx
   creationTimestamp: "2025-09-05T02:22:47Z"
-  generation: 2
+  generation: 3
   name: bar
   namespace: apps
   resourceVersion: "219440"
@@ -19,9 +19,9 @@
       paths:
       - backend:
           service:
-            name: http
+            name: bar
             port:
-              number: 80
+              name: web
         path: /
         pathType: Prefix
 status:
➜  DevOps-Kubernetes-GoodNotes git:(main-udpate-ingress-config) ✗ 

```

```diff
➜  DevOps-Kubernetes-GoodNotes git:(main-udpate-ingress-config) ✗ k diff -k kind-goodnotes-k8s-demo/apps/foo 
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-2913765136/networking.k8s.io.v1.Ingress.apps.foo /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-357865560/networking.k8s.io.v1.Ingress.apps.foo
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-2913765136/networking.k8s.io.v1.Ingress.apps.foo      2025-09-05 12:27:48
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-357865560/networking.k8s.io.v1.Ingress.apps.foo     2025-09-05 12:27:48
@@ -6,7 +6,7 @@
       {"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"nginx"},"name":"foo","namespace":"apps"},"spec":{"ingressClassName":"nginx","rules":[{"host":"foo.localhost","http":{"paths":[{"backend":{"service":{"name":"http","port":{"number":80}}},"path":"/","pathType":"Prefix"}]}}]}}
     kubernetes.io/ingress.class: nginx
   creationTimestamp: "2025-09-05T02:23:01Z"
-  generation: 2
+  generation: 3
   name: foo
   namespace: apps
   resourceVersion: "219441"
@@ -19,9 +19,9 @@
       paths:
       - backend:
           service:
-            name: http
+            name: foo
             port:
-              number: 80
+              name: http
         path: /
         pathType: Prefix
 status:
➜  DevOps-Kubernetes-GoodNotes git:(main-udpate-ingress-config) ✗  
```