### PR TITLE
adding k6 namespace

### DIFF
--- a/kind-goodnotes-k8s-demo/namespaces/namespaces.yaml
+++ b/kind-goodnotes-k8s-demo/namespaces/namespaces.yaml
@@ -36,4 +36,11 @@ metadata:
     namespace: apps
     kubernetes.io/metadata.name: apps
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k6
+  labels:
+    namespace: k6
+    kubernetes.io/metadata.name: k6
 


### PR DESCRIPTION
kubectl diff 
```diff
➜  DevOps-Kubernetes-GoodNotes git:(main-adding-k6-namespace) ✗ k diff -k kind-goodnotes-k8s-demo/namespaces 
diff -u -N /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-3687814565/v1.Namespace..k6 /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-362111323/v1.Namespace..k6
--- /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/LIVE-3687814565/v1.Namespace..k6   2025-09-08 11:04:31
+++ /var/folders/c6/g4630qlx2z125sq_5df7dj2h0000gn/T/MERGED-362111323/v1.Namespace..k6  2025-09-08 11:04:31
@@ -0,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: "2025-09-08T03:04:31Z"
+  labels:
+    kubernetes.io/metadata.name: k6
+    namespace: k6
+  name: k6
+  uid: 986d23f1-f261-41d0-9800-09e59d8b21ac
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
➜  DevOps-Kubernetes-GoodNotes git:(main-adding-k6-namespace) ✗ 
```