### PR TITLE
corssplane major updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This README documents the `kubernetes-platform-engineering` repository against t
 - **Workload baselines**: `foo`, `bar`, and `iris-sklearn-api` are deployed in the `apps` namespace and currently route through Gateway API `HTTPRoute` objects.
 - **Traffic layers**: the repo contains both an NGINX Ingress controller stack and Envoy Gateway assets (`gateway/` CRDs plus `gateway-controller/` controller manifests).
 - **Observability**: Prometheus/Grafana, OTEL Collector, Loki, Mimir, and Tempo all have manifests under `kind-goodnotes-k8s-demo/`.
-- **Storage and GitOps**: MinIO operator and tenant resources are present, along with Argo CD manifests.
+- **Storage, GitOps, and control planes**: MinIO operator and tenant resources are present, along with Argo CD and Crossplane manifests.
 - **Performance engineering**: a Python ingress load generator lives in `scripts/load-test.py`, and the k6 operator manifests live in `kind-goodnotes-k8s-demo/k6/`.
 - **Profiling and diagnosis**: `go-apps/main.go` starts several intentionally hot code paths plus `pprof` on `localhost:6060`.
 
@@ -38,6 +38,8 @@ This README documents the `kubernetes-platform-engineering` repository against t
 ├── kind-goodnotes-k8s-demo/
 │   ├── apps/                    # baseline workloads
 │   ├── argocd/                  # Argo CD manifests
+│   ├── crossplane/              # Crossplane control plane install
+│   ├── crossplane-managed-kind/ # Crossplane-managed child Kind cluster example
 │   ├── coredns/                 # Supporting CoreDNS config snippets
 │   ├── crd/                     # Supporting CRDs
 │   ├── gateway/                 # Gateway API install assets (not a kustomize root)
@@ -88,6 +90,7 @@ This README documents the `kubernetes-platform-engineering` repository against t
 
    ```sh
    kubectl apply -k kind-goodnotes-k8s-demo/argocd
+   kubectl apply -k kind-goodnotes-k8s-demo/crossplane
    kubectl apply -k kind-goodnotes-k8s-demo/k6
    kubectl apply -k kind-goodnotes-k8s-demo/minio-operator
    kubectl apply -k kind-goodnotes-k8s-demo/minio
@@ -109,9 +112,10 @@ This README documents the `kubernetes-platform-engineering` repository against t
 ## Current live cluster snapshot
 
 Verified on 2026-03-30 against `kubectl config current-context = kind-goodnotes-k8s-demo`.
+Crossplane was additionally installed and verified on 2026-05-20.
 
 - **Nodes**: `goodnotes-k8s-demo-control-plane` plus `worker`, `worker2`, `worker3`, all `Ready`.
-- **Namespaces from this repo are present**: `addons`, `apps`, `argocd`, `gateway`, `ingress-nginx`, `k6`, and `monitoring`.
+- **Namespaces from this repo are present**: `addons`, `apps`, `argocd`, `crossplane-system`, `gateway`, `ingress-nginx`, `k6`, and `monitoring`.
 - **Gateway API is active**: `gateway/public-gateway` is `Programmed=True`.
 - **Application routes are Gateway API based**:
   - `apps/foo` for `foo.localhost`
@@ -122,7 +126,7 @@ Verified on 2026-03-30 against `kubectl config current-context = kind-goodnotes-
   - `monitoring/promethues` for `prometheus.localhost`
 - **Observed running stacks**:
   - baseline workloads: `foo`, `bar`, `iris-sklearn-api`
-  - platform: Argo CD, k6 operator, Envoy Gateway, MinIO operator, Prometheus/Grafana, Loki, Mimir, OTEL, Tempo
+  - platform: Argo CD, Crossplane, k6 operator, Envoy Gateway, MinIO operator, Prometheus/Grafana, Loki, Mimir, OTEL, Tempo
   - additional runtime-only workloads in `apps`: `agent-coordinator`, `execution-agent`, `market-data-adapter`, `notification-gateway`, `openclaw-discord-gateway`, `portfolio-watcher`, `trading-console`, `trading-core`, `postgres`, `postgres-exporter`, plus several CronJob-created completed Jobs
 
 The important boundary is that the live cluster has moved beyond the repository's baseline platform definition. This repo still provides the core platform and workload manifests, while the running cluster currently hosts extra OpenClaw/trading services that are only partially reflected here through Grafana dashboards and observability config.
@@ -189,6 +193,6 @@ On 2026-03-30, `kubectl` confirmed the cluster state above, but `curl -H 'Host: 
 
 ## Notes
 
-- Not every directory under `kind-goodnotes-k8s-demo/` is a standalone kustomize root. The confirmed roots are `argocd`, `ingress-controller`, `k6`, `loki`, `mimir`, `minio-operator`, `minio`, `namespaces`, `otel-collector`, and `tempo`, plus the three app directories.
+- Not every directory under `kind-goodnotes-k8s-demo/` is a standalone kustomize root. The confirmed roots are `argocd`, `crossplane`, `ingress-controller`, `k6`, `loki`, `mimir`, `minio-operator`, `minio`, `namespaces`, `otel-collector`, and `tempo`, plus the three app directories.
 - `kind-goodnotes-k8s-demo/gateway/` currently holds install assets such as `standard-install.yaml`; `kind-goodnotes-k8s-demo/gateway-controller/` is applied from the rendered `manifest.yaml`.
 - Several repo files are clearly operational scratchpads or generated artifacts. This README intentionally documents the maintained platform surfaces rather than every untracked local file in the worktree.

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/README.md
@@ -1,0 +1,117 @@
+## Goal
+
+Use the current `kind-goodnotes-k8s-demo` cluster as the Crossplane management cluster, and a second Kind cluster named `crossplane-workload` as the managed workload cluster.
+
+Crossplane does not create a Kind cluster from inside Kubernetes. The Kind cluster is created on the host with Docker, then registered into Crossplane with `provider-kubernetes`.
+
+## 1. Create the workload Kind cluster
+
+```sh
+kind create cluster \
+  --name crossplane-workload \
+  --config goodnotes-k8s-demo/cluster-config-crossplane-workload.yaml
+```
+
+## 2. Store the child cluster kubeconfig for Crossplane
+
+```sh
+CHILD_APISERVER_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' crossplane-workload-control-plane)
+
+kind get kubeconfig --name crossplane-workload \
+  | sed -E "s#server: https://127.0.0.1:[0-9]+#server: https://${CHILD_APISERVER_IP}:6443#" \
+  | kubectl --context kind-goodnotes-k8s-demo -n crossplane-system \
+  create secret generic crossplane-workload-kubeconfig \
+  --from-file=kubeconfig=/dev/stdin \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The default `kind get kubeconfig` output uses a host loopback endpoint such as `https://127.0.0.1:59749`.
+That endpoint works on the host, but not from the `provider-kubernetes` Pod inside the management cluster, so the API server endpoint must be rewritten to the child Kind control-plane container IP.
+
+## 3. Install the Crossplane Kubernetes provider
+
+```sh
+kubectl --context kind-goodnotes-k8s-demo apply -k \
+  kind-goodnotes-k8s-demo/crossplane-managed-kind/provider
+
+kubectl --context kind-goodnotes-k8s-demo wait \
+  --for=condition=Healthy provider.pkg/provider-kubernetes \
+  --timeout=180s
+```
+
+## 4. Register the workload cluster and push demo resources
+
+```sh
+kubectl --context kind-goodnotes-k8s-demo apply -k \
+  kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster
+```
+
+## 5. Verify from the child cluster
+
+```sh
+kubectl --context kind-crossplane-workload get ns platform-demo
+kubectl --context kind-crossplane-workload -n platform-demo get configmap platform-demo-settings -o yaml
+```
+
+## 6. Install the Crossplane Helm provider and a demo release
+
+```sh
+kubectl --context kind-goodnotes-k8s-demo apply -k \
+  kind-goodnotes-k8s-demo/crossplane-managed-kind/provider
+
+kubectl --context kind-goodnotes-k8s-demo wait \
+  --for=condition=Healthy provider.pkg/provider-helm \
+  --timeout=180s
+
+kubectl --context kind-goodnotes-k8s-demo apply -k \
+  kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload
+```
+
+## 7. Verify the Helm release from the child cluster
+
+```sh
+kubectl --context kind-crossplane-workload get ns helm-demo
+kubectl --context kind-crossplane-workload -n helm-demo get deploy,pods,svc
+```
+
+## Notes
+
+- `provider-kubernetes` is pinned to `v1.2.1`.
+- `provider-helm` is pinned to `v1.0.4`.
+- The manifests in `workload-cluster/` prove that Crossplane can reconcile Kubernetes objects into the child Kind cluster.
+- The manifests in `helm-workload/` prove that Crossplane can install and manage a Helm release in the child Kind cluster.
+- The demo Helm release uses `bitnami/nginx` chart `22.4.2` with `replicaCount: 0`. This keeps the reconciliation path green even when the child Kind nodes cannot pull external images because of the local proxy configuration.
+
+## Useful CLI commands
+
+The installed CLI is `crossplane` and the current major commands are `resource` and `cluster`.
+This CLI version does not use the older `crossplane beta ...` entrypoint.
+
+```sh
+crossplane version
+
+crossplane resource trace \
+  provider.pkg.crossplane.io/provider-kubernetes \
+  --context kind-goodnotes-k8s-demo \
+  -o wide
+
+crossplane resource trace \
+  object.kubernetes.crossplane.io/crossplane-workload-platform-demo-namespace \
+  --context kind-goodnotes-k8s-demo \
+  -o wide
+
+crossplane resource trace \
+  release.helm.crossplane.io/crossplane-workload-nginx \
+  --context kind-goodnotes-k8s-demo \
+  -o wide
+
+crossplane cluster top
+```
+
+Expected current results:
+
+- `crossplane version` reports `Client Version: v2.3.0` and `Server Version: v2.2.1`
+- tracing `provider-kubernetes` shows the active `ProviderRevision`
+- tracing `crossplane-workload-platform-demo-namespace` shows `SYNCED=True` and `READY=True`
+- tracing `crossplane-workload-nginx` shows `SYNCED=True` and `READY=True`
+- `crossplane cluster top` returns CPU and memory for the `crossplane`, `crossplane-rbac-manager`, and `provider-kubernetes` pods

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - provider-config.yaml
+  - nginx-release.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/nginx-release.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/nginx-release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: crossplane-workload-nginx
+spec:
+  providerConfigRef:
+    name: crossplane-workload
+  forProvider:
+    namespace: helm-demo
+    wait: true
+    waitTimeout: 5m
+    chart:
+      repository: https://charts.bitnami.com/bitnami
+      name: nginx
+      version: 22.4.2
+    values:
+      replicaCount: 0
+      service:
+        type: ClusterIP

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/provider-config.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/helm-workload/provider-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: crossplane-workload
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: crossplane-workload-kubeconfig
+      key: kubeconfig

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - provider-kubernetes.yaml
+  - provider-helm.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/provider-helm.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/provider-helm.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-helm
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.0.4

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/provider-kubernetes.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/provider/provider-kubernetes.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.2.1

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/demo-configmap.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/demo-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: kubernetes.crossplane.io/v1alpha2
+kind: Object
+metadata:
+  name: crossplane-workload-platform-demo-config
+spec:
+  providerConfigRef:
+    name: crossplane-workload
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: platform-demo-settings
+        namespace: platform-demo
+        labels:
+          managed-by: crossplane
+      data:
+        owner: crossplane
+        targetCluster: crossplane-workload
+        targetContext: kind-crossplane-workload

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/demo-namespace.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/demo-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: kubernetes.crossplane.io/v1alpha2
+kind: Object
+metadata:
+  name: crossplane-workload-platform-demo-namespace
+spec:
+  providerConfigRef:
+    name: crossplane-workload
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: platform-demo
+        labels:
+          managed-by: crossplane
+          environment: demo

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - provider-config.yaml
+  - demo-namespace.yaml
+  - demo-configmap.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/provider-config.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-managed-kind/workload-cluster/provider-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: crossplane-workload
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: crossplane-workload-kubeconfig
+      key: kubeconfig

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/README.md
@@ -1,0 +1,92 @@
+# Crossplane AWS Platform Network
+
+This root defines an owner-style Crossplane platform API for an AWS VPC-backed network boundary.
+
+## Design boundary
+
+This API models a platform network, not a raw AWS VPC primitive.
+
+- Owner XR: `XNetwork`
+- Managed resources: `VPC`, `InternetGateway`, `RouteTable`, `Route`, `Subnet`, `RouteTableAssociation`
+- Ownership rule: this XR owns the shared network lifecycle end to end
+- Non-goal: consumer teams passing raw `vpcId`, `subnetIds`, or `routeTableIds`
+- Managed resource namespace: `crossplane-system`
+
+The API follows the Crossplane platform design skill:
+
+- expose owner intent: `networkClass`, `region`, `cidrBlock`, `publicSubnets`, `privateSubnets`
+- hide consumer-hostile details: no `vpcId`, no `subnetIds`, no `routeTableIds`, no AWS selector fields
+- make ownership explicit: delete the XR and the owned VPC topology is deleted too unless `deletionPolicy: Orphan`
+
+## Owner vs consumer split
+
+This XR is deliberately owner-scoped because network topology is a shared lifecycle boundary.
+
+That means this Composition creates and reconciles:
+
+- one VPC
+- one Internet Gateway
+- one public route table plus public default route
+- one private route table
+- two public subnets
+- two private subnets
+- route table associations for all four subnets
+
+What it does not do:
+
+- expose raw cloud IDs as input
+- let application teams mutate shared route tables
+- mix network ownership with downstream consumers such as EKS, RDS, or Security Group rules
+- create NAT gateways, because that is a separate blast-radius and cost decision
+
+If a downstream platform API needs network access, it should reference this owner XR by logical name,
+for example `networkRef.name: shared-dev-network`, and resolve the underlying VPC or subnet through labels
+or status produced by this owner Composition.
+
+## Labels exported for consumers
+
+The Composition stamps the following stable labels onto owner-managed resources:
+
+- `platform.aws.goodnotes.io/network: <xr-name>`
+- `platform.aws.goodnotes.io/network-class: <networkClass>`
+- `platform.aws.goodnotes.io/resource-role: vpc|subnet|route-table|internet-gateway|route-table-association`
+- `platform.aws.goodnotes.io/subnet-visibility: public|private`
+- `platform.aws.goodnotes.io/subnet-slot: a|b`
+
+This keeps consumer APIs reference-based rather than ID-based.
+
+## Status exported by the owner XR
+
+The XR surfaces:
+
+- `status.vpcId`
+- `status.vpcArn`
+- `status.internetGatewayId`
+- `status.publicRouteTableId`
+- `status.privateRouteTableId`
+- `status.publicSubnetIds.a`
+- `status.publicSubnetIds.b`
+- `status.privateSubnetIds.a`
+- `status.privateSubnetIds.b`
+
+These are outputs for automation or inspection, not inputs for consumer APIs.
+
+## Apply API
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-network
+```
+
+## Apply instances
+
+For day-2 usage, manage network instances under [`instances/`](./instances).
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances
+```
+
+You can also apply a single example directly:
+
+```sh
+kubectl apply -f kind-goodnotes-k8s-demo/crossplane-platform-aws-network/examples/shared-dev-network.yaml
+```

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/composition.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/composition.yaml
@@ -1,0 +1,786 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnetworks.platform.aws.goodnotes.io
+  labels:
+    platform.aws.goodnotes.io/composition-role: owner
+    platform.aws.goodnotes.io/type: network
+spec:
+  compositeTypeRef:
+    apiVersion: platform.aws.goodnotes.io/v1alpha1
+    kind: XNetwork
+  resources:
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: VPC
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: vpc
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            assignGeneratedIpv6CidrBlock: false
+            cidrBlock: 10.0.0.0/16
+            enableDnsHostnames: true
+            enableDnsSupport: true
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-vpc"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: spec.forProvider.tags["network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.vpcArn
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.vpcId
+          policy:
+            fromFieldPath: Optional
+    - name: internet-gateway
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: InternetGateway
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: internet-gateway
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-igw"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.internetGatewayId
+          policy:
+            fromFieldPath: Optional
+    - name: public-route-table
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTable
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table
+            platform.aws.goodnotes.io/route-table-scope: public
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-public-rt"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.publicRouteTableId
+          policy:
+            fromFieldPath: Optional
+    - name: private-route-table
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTable
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table
+            platform.aws.goodnotes.io/route-table-scope: private
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-private-rt"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.privateRouteTableId
+          policy:
+            fromFieldPath: Optional
+    - name: public-default-route
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: Route
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route
+            platform.aws.goodnotes.io/route-scope: public-egress
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            destinationCidrBlock: 0.0.0.0/0
+            gatewayIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: internet-gateway
+            region: us-west-2
+            routeTableIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: route-table
+                platform.aws.goodnotes.io/route-table-scope: public
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.gatewayIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.routeTableIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+    - name: public-subnet-a
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: Subnet
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: subnet
+            platform.aws.goodnotes.io/subnet-slot: a
+            platform.aws.goodnotes.io/subnet-visibility: public
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            availabilityZone: us-west-2a
+            cidrBlock: 10.0.0.0/24
+            mapPublicIpOnLaunch: true
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.publicSubnets.a.availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.publicSubnets.a.cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-public-a"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: spec.forProvider.tags["network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.publicSubnetIds.a
+          policy:
+            fromFieldPath: Optional
+    - name: public-subnet-b
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: Subnet
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: subnet
+            platform.aws.goodnotes.io/subnet-slot: b
+            platform.aws.goodnotes.io/subnet-visibility: public
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            availabilityZone: us-west-2b
+            cidrBlock: 10.0.1.0/24
+            mapPublicIpOnLaunch: true
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.publicSubnets.b.availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.publicSubnets.b.cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-public-b"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: spec.forProvider.tags["network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.publicSubnetIds.b
+          policy:
+            fromFieldPath: Optional
+    - name: private-subnet-a
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: Subnet
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: subnet
+            platform.aws.goodnotes.io/subnet-slot: a
+            platform.aws.goodnotes.io/subnet-visibility: private
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            availabilityZone: us-west-2a
+            cidrBlock: 10.0.10.0/24
+            mapPublicIpOnLaunch: false
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.privateSubnets.a.availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.privateSubnets.a.cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-private-a"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: spec.forProvider.tags["network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.privateSubnetIds.a
+          policy:
+            fromFieldPath: Optional
+    - name: private-subnet-b
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: Subnet
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: subnet
+            platform.aws.goodnotes.io/subnet-slot: b
+            platform.aws.goodnotes.io/subnet-visibility: private
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            availabilityZone: us-west-2b
+            cidrBlock: 10.0.11.0/24
+            mapPublicIpOnLaunch: false
+            region: us-west-2
+            tags:
+              Name: replace-me
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: vpc
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.privateSubnets.b.availabilityZone
+          toFieldPath: spec.forProvider.availabilityZone
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.privateSubnets.b.cidrBlock
+          toFieldPath: spec.forProvider.cidrBlock
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
+          transforms:
+            - type: string
+              string:
+                type: Format
+                fmt: "%s-private-b"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkClass
+          toFieldPath: spec.forProvider.tags["network-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.privateSubnetIds.b
+          policy:
+            fromFieldPath: Optional
+    - name: public-subnet-a-association
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table-association
+            platform.aws.goodnotes.io/subnet-slot: a
+            platform.aws.goodnotes.io/subnet-visibility: public
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            routeTableIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: route-table
+                platform.aws.goodnotes.io/route-table-scope: public
+            subnetIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: subnet
+                platform.aws.goodnotes.io/subnet-slot: a
+                platform.aws.goodnotes.io/subnet-visibility: public
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.routeTableIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+    - name: public-subnet-b-association
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table-association
+            platform.aws.goodnotes.io/subnet-slot: b
+            platform.aws.goodnotes.io/subnet-visibility: public
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            routeTableIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: route-table
+                platform.aws.goodnotes.io/route-table-scope: public
+            subnetIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: subnet
+                platform.aws.goodnotes.io/subnet-slot: b
+                platform.aws.goodnotes.io/subnet-visibility: public
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.routeTableIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+    - name: private-subnet-a-association
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table-association
+            platform.aws.goodnotes.io/subnet-slot: a
+            platform.aws.goodnotes.io/subnet-visibility: private
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            routeTableIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: route-table
+                platform.aws.goodnotes.io/route-table-scope: private
+            subnetIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: subnet
+                platform.aws.goodnotes.io/subnet-slot: a
+                platform.aws.goodnotes.io/subnet-visibility: private
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.routeTableIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+    - name: private-subnet-b-association
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+            platform.aws.goodnotes.io/resource-role: route-table-association
+            platform.aws.goodnotes.io/subnet-slot: b
+            platform.aws.goodnotes.io/subnet-visibility: private
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            region: us-west-2
+            routeTableIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: route-table
+                platform.aws.goodnotes.io/route-table-scope: private
+            subnetIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+                platform.aws.goodnotes.io/resource-role: subnet
+                platform.aws.goodnotes.io/subnet-slot: b
+                platform.aws.goodnotes.io/subnet-visibility: private
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.routeTableIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/examples/shared-dev-network.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/examples/shared-dev-network.yaml
@@ -1,0 +1,65 @@
+apiVersion: platform.aws.goodnotes.io/v1alpha1
+kind: XNetwork
+metadata:
+  # This is the owner XR name.
+  #
+  # The Composition also projects this value into stable labels such as:
+  #   platform.aws.goodnotes.io/network: shared-dev-network
+  #
+  # Downstream consumer APIs should reference this logical name through
+  # networkRef.name instead of passing raw AWS VPC or subnet IDs.
+  name: shared-dev-network
+spec:
+  parameters:
+    # The top-level VPC CIDR owned by this platform network.
+    #
+    # This is owner intent, not a consumer-facing detail. The Composition
+    # patches it into the managed AWS VPC resource as spec.forProvider.cidrBlock.
+    cidrBlock: 10.40.0.0/16
+    # Intent-level classification for governance and policy.
+    #
+    # Use this to describe what kind of shared network this is. Do not create
+    # separate APIs that select AWS resources directly by tag or ID.
+    networkClass: shared
+    privateSubnets:
+      # Private subnet slot "a".
+      #
+      # This subnet is created by the owner Composition and labeled as:
+      #   subnet-visibility: private
+      #   subnet-slot: a
+      #
+      # Consumer APIs can later select or derive the right subnet through those
+      # stable labels or XR status outputs, rather than receiving subnet IDs.
+      a:
+        # The concrete AWS availability zone for this subnet.
+        availabilityZone: ap-southeast-1a
+        # The CIDR block reserved for private subnet "a".
+        cidrBlock: 10.40.10.0/24
+      # Private subnet slot "b" for multi-AZ topology.
+      b:
+        availabilityZone: ap-southeast-1b
+        cidrBlock: 10.40.11.0/24
+    providerConfigRef:
+      # Optional Crossplane provider config override.
+      #
+      # Omit this block if you want to use the Composition default provider
+      # config. Keep it only when this network must reconcile against a
+      # non-default AWS credential or account boundary.
+      name: default
+    publicSubnets:
+      # Public subnet slot "a".
+      #
+      # The Composition attaches this subnet to the public route table and
+      # enables public IP mapping on launch. This is owner-managed topology.
+      a:
+        availabilityZone: ap-southeast-1a
+        cidrBlock: 10.40.0.0/24
+      # Public subnet slot "b" for multi-AZ ingress-facing capacity.
+      b:
+        availabilityZone: ap-southeast-1b
+        cidrBlock: 10.40.1.0/24
+    # AWS region for the whole network boundary.
+    #
+    # All managed resources in this Composition, including VPC, subnets, route
+    # tables, and internet gateway, are reconciled in this region.
+    region: ap-southeast-1

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/README.md
@@ -1,0 +1,33 @@
+# Network Instances
+
+Put each owner-managed network instance in its own file in this directory.
+
+## Add a new network
+
+1. Copy an existing instance file.
+2. Change `metadata.name`.
+3. Adjust `networkClass`, `region`, `cidrBlock`, `publicSubnets`, and `privateSubnets`.
+4. Add the new file to [kustomization.yaml](./kustomization.yaml).
+5. Apply the instances root.
+
+Field guide:
+
+- `metadata.name`: logical network name; downstream consumer XRs should reference this through `networkRef.name`.
+- `networkClass`: intent-level category for governance and policy.
+- `cidrBlock`: VPC CIDR for the owner-managed network boundary.
+- `publicSubnets`: public subnet topology patched into AWS Subnet resources.
+- `privateSubnets`: private subnet topology patched into AWS Subnet resources.
+- `region`: AWS region for the full network topology.
+- `providerConfigRef.name`: optional AWS provider config override; omit it to use the Composition default.
+
+Example:
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances
+```
+
+## Notes
+
+- `metadata.name` is exported as the stable `platform.aws.goodnotes.io/network` label.
+- Consumers should reference this logical name instead of passing raw AWS IDs.
+- NAT is intentionally not part of this API. If you need managed outbound egress for private subnets, add a separate owner API or extend this one with a deliberate topology review.

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/kustomization.yaml
@@ -1,0 +1,7 @@
+# Add one file per network instance here.
+# To create a new network:
+# 1. Copy an existing instance YAML in this directory.
+# 2. Change metadata.name and spec.parameters values.
+# 3. Add the new filename to resources below.
+resources:
+  - shared-dev-network.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/shared-dev-network.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/instances/shared-dev-network.yaml
@@ -1,0 +1,50 @@
+apiVersion: platform.aws.goodnotes.io/v1alpha1
+kind: XNetwork
+metadata:
+  # This is the logical owner network name.
+  #
+  # It becomes the stable platform label used by downstream consumers:
+  #   platform.aws.goodnotes.io/network: shared-dev-network
+  #
+  # Keep this value durable. Renaming it changes the reference boundary that
+  # other consumer XRs are expected to use via networkRef.name.
+  name: shared-dev-network
+spec:
+  parameters:
+    # Owner-managed VPC CIDR.
+    #
+    # This XR owns the VPC lifecycle, so this field belongs here. A consumer XR
+    # should never be asked for a raw vpcId or route table identifier.
+    cidrBlock: 10.40.0.0/16
+    # Intent-level network category.
+    #
+    # This is a policy and governance signal, not an AWS implementation field.
+    networkClass: shared
+    privateSubnets:
+      # Private subnet "a" stays behind the private route table.
+      a:
+        # Concrete AWS AZ chosen by the platform owner.
+        availabilityZone: ap-southeast-1a
+        # Private address space reserved for workloads in AZ "a".
+        cidrBlock: 10.40.10.0/24
+      # Private subnet "b" provides the second failure domain.
+      b:
+        availabilityZone: ap-southeast-1b
+        cidrBlock: 10.40.11.0/24
+    providerConfigRef:
+      # Optional provider config override.
+      #
+      # Leave this block out if the Composition default should be used.
+      name: default
+    publicSubnets:
+      # Public subnet "a" is intended for ingress-facing or edge-attached
+      # resources that need the public route table.
+      a:
+        availabilityZone: ap-southeast-1a
+        cidrBlock: 10.40.0.0/24
+      # Public subnet "b" mirrors the topology in a second AZ.
+      b:
+        availabilityZone: ap-southeast-1b
+        cidrBlock: 10.40.1.0/24
+    # Region for the entire owner-managed topology.
+    region: ap-southeast-1

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - xrd.yaml
+  - composition.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/xrd.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-network/xrd.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnetworks.platform.aws.goodnotes.io
+spec:
+  group: platform.aws.goodnotes.io
+  names:
+    kind: XNetwork
+    plural: xnetworks
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  required:
+                    - cidrBlock
+                    - networkClass
+                    - privateSubnets
+                    - publicSubnets
+                    - region
+                  properties:
+                    cidrBlock:
+                      type: string
+                      description: Primary IPv4 CIDR block for the owner-managed VPC.
+                    deletionPolicy:
+                      type: string
+                      description: Crossplane deletion policy for the managed AWS resources.
+                      enum:
+                        - Delete
+                        - Orphan
+                    networkClass:
+                      type: string
+                      description: Intent-level classification for this network boundary.
+                      enum:
+                        - shared
+                        - application
+                        - data
+                    privateSubnets:
+                      type: object
+                      description: Owner-defined private subnet topology.
+                      required:
+                        - a
+                        - b
+                      properties:
+                        a:
+                          type: object
+                          required:
+                            - availabilityZone
+                            - cidrBlock
+                          properties:
+                            availabilityZone:
+                              type: string
+                            cidrBlock:
+                              type: string
+                        b:
+                          type: object
+                          required:
+                            - availabilityZone
+                            - cidrBlock
+                          properties:
+                            availabilityZone:
+                              type: string
+                            cidrBlock:
+                              type: string
+                    providerConfigRef:
+                      type: object
+                      description: Optional Crossplane AWS provider config override.
+                      properties:
+                        name:
+                          type: string
+                    publicSubnets:
+                      type: object
+                      description: Owner-defined public subnet topology.
+                      required:
+                        - a
+                        - b
+                      properties:
+                        a:
+                          type: object
+                          required:
+                            - availabilityZone
+                            - cidrBlock
+                          properties:
+                            availabilityZone:
+                              type: string
+                            cidrBlock:
+                              type: string
+                        b:
+                          type: object
+                          required:
+                            - availabilityZone
+                            - cidrBlock
+                          properties:
+                            availabilityZone:
+                              type: string
+                            cidrBlock:
+                              type: string
+                    region:
+                      type: string
+                      description: AWS region for the owner-managed VPC topology.
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                internetGatewayId:
+                  type: string
+                privateRouteTableId:
+                  type: string
+                privateSubnetIds:
+                  type: object
+                  properties:
+                    a:
+                      type: string
+                    b:
+                      type: string
+                publicRouteTableId:
+                  type: string
+                publicSubnetIds:
+                  type: object
+                  properties:
+                    a:
+                      type: string
+                    b:
+                      type: string
+                vpcArn:
+                  type: string
+                vpcId:
+                  type: string

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/README.md
@@ -1,0 +1,71 @@
+# Crossplane AWS Shared Security Group
+
+This root defines an owner-style Crossplane platform API for an AWS Security Group.
+
+## Design boundary
+
+This API intentionally models a shared security boundary, not a raw AWS EC2 primitive.
+
+- Owner XR: `XSharedSecurityGroup`
+- Managed resource: `SecurityGroup.ec2.aws.m.upbound.io`
+- Ownership rule: this XR owns the Security Group lifecycle
+- Non-goal: consumer teams editing the same shared Security Group or passing raw `vpcId`
+- Managed resource namespace: `crossplane-system`
+
+The API follows the platform design rule from the Crossplane skill:
+
+- expose intent: `boundaryClass`, `networkRef`, `region`
+- hide implementation: no `vpcId`, no `securityGroupId`, no ingress or egress rule fields
+
+If application teams need access rules, model them in a separate consumer XR that creates
+`SecurityGroupIngressRule` or `SecurityGroupEgressRule` resources against this owner-managed
+group. Do not let multiple teams co-own the same Security Group object.
+
+## Network dependency
+
+`spec.parameters.networkRef.name` is mapped into a selector:
+
+```yaml
+spec:
+  forProvider:
+    vpcIdSelector:
+      matchLabels:
+        platform.aws.goodnotes.io/network: <networkRef.name>
+```
+
+That means the owner-managed VPC resource must carry the same label, for example:
+
+```yaml
+metadata:
+  labels:
+    platform.aws.goodnotes.io/network: shared-dev-network
+```
+
+This keeps the XR API reference-based and avoids leaking raw AWS IDs into the platform API.
+
+## Apply API
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group
+```
+
+## Apply instances
+
+For day-2 usage, manage SG instances under [`instances/`](./instances).
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances
+```
+
+To add a new SG:
+
+1. Copy one file from [`instances/`](./instances).
+2. Change `metadata.name` and the values under `spec.parameters`.
+3. Add the file to [`instances/kustomization.yaml`](./instances/kustomization.yaml).
+4. Re-apply the instances root.
+
+If you only want to create one SG ad hoc, you can still apply a single manifest directly:
+
+```sh
+kubectl apply -f kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/examples/shared-services-security-group.yaml
+```

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/composition.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/composition.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xsharedsecuritygroups.platform.aws.goodnotes.io
+  labels:
+    platform.aws.goodnotes.io/composition-role: owner
+    platform.aws.goodnotes.io/type: shared-security-group
+spec:
+  compositeTypeRef:
+    apiVersion: platform.aws.goodnotes.io/v1alpha1
+    kind: XSharedSecurityGroup
+  resources:
+    - name: security-group
+      base:
+        apiVersion: ec2.aws.m.upbound.io/v1beta1
+        kind: SecurityGroup
+        metadata:
+          namespace: crossplane-system
+          labels:
+            platform.aws.goodnotes.io/managed-by: crossplane
+        spec:
+          deletionPolicy: Delete
+          providerConfigRef:
+            name: default
+          forProvider:
+            description: owner-managed shared security boundary
+            revokeRulesOnDelete: true
+            region: us-west-2
+            tags:
+              managed-by: crossplane
+            vpcIdSelector:
+              matchLabels:
+                platform.aws.goodnotes.io/network: replace-me
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/security-boundary"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.boundaryClass
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/boundary-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.boundaryClass
+          toFieldPath: spec.forProvider.tags["boundary-class"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkRef.name
+          toFieldPath: metadata.labels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkRef.name
+          toFieldPath: spec.forProvider.tags["network-ref"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.networkRef.name
+          toFieldPath: spec.forProvider.vpcIdSelector.matchLabels["platform.aws.goodnotes.io/network"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.description
+          toFieldPath: spec.forProvider.description
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.arn
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.securityGroupId
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.vpcId
+          toFieldPath: status.vpcId
+          policy:
+            fromFieldPath: Optional

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/examples/shared-services-security-group.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/examples/shared-services-security-group.yaml
@@ -1,0 +1,11 @@
+apiVersion: platform.aws.goodnotes.io/v1alpha1
+kind: XSharedSecurityGroup
+metadata:
+  name: shared-services
+spec:
+  parameters:
+    boundaryClass: internal-services
+    description: Shared security boundary for platform-managed internal services.
+    networkRef:
+      name: shared-dev-network
+    region: ap-southeast-1

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/README.md
@@ -1,0 +1,31 @@
+# Shared Security Group Instances
+
+Put each shared security group instance in its own file in this directory.
+
+## Add a new security group
+
+1. Copy an existing instance file.
+2. Change `metadata.name`.
+3. Adjust `boundaryClass`, `description`, `networkRef.name`, and `region`.
+4. Add the new file to [kustomization.yaml](./kustomization.yaml).
+5. Apply the instances root.
+
+Field guide:
+
+- `metadata.name`: unique SG name; the Composition patches this into the AWS Security Group name.
+- `boundaryClass`: intent-level category for the shared boundary.
+- `description`: operator-facing description in AWS.
+- `networkRef.name`: logical network reference; this must match the label on the owner-managed VPC.
+- `region`: AWS region for the SG.
+
+Example:
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances
+```
+
+## Notes
+
+- `metadata.name` becomes the AWS Security Group name through the Composition patch.
+- `networkRef.name` must match the label on the owner-managed VPC resource.
+- Keep access rules in a separate consumer API. Do not extend this owner instance with ingress or egress rule details.

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/kustomization.yaml
@@ -1,0 +1,8 @@
+# Add one file per shared security group instance here.
+# To create a new SG:
+# 1. Copy an existing instance YAML in this directory.
+# 2. Change metadata.name and spec.parameters values.
+# 3. Add the new filename to resources below.
+resources:
+  - shared-services.yaml
+  - payments-internal.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/payments-internal.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/payments-internal.yaml
@@ -1,0 +1,13 @@
+apiVersion: platform.aws.goodnotes.io/v1alpha1
+kind: XSharedSecurityGroup
+metadata:
+  # To add another SG, copy this file, rename it, and change this name first.
+  name: payments-internal
+spec:
+  parameters:
+    # Keep this API intent-focused. Do not add raw vpcId or ingress/egress rules here.
+    boundaryClass: internal-services
+    description: Shared security boundary for payments internal services.
+    networkRef:
+      name: shared-dev-network
+    region: ap-southeast-1

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/shared-services.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/instances/shared-services.yaml
@@ -1,0 +1,16 @@
+apiVersion: platform.aws.goodnotes.io/v1alpha1
+kind: XSharedSecurityGroup
+metadata:
+  # This becomes the XR name and is also patched into the AWS Security Group name.
+  name: shared-services
+spec:
+  parameters:
+    # Pick the intent-level class for this shared boundary.
+    boundaryClass: internal-services
+    # Free-form description shown on the AWS Security Group.
+    description: Shared security boundary for platform-managed internal services.
+    networkRef:
+      # Must match the platform label on the owner-managed VPC resource.
+      name: shared-dev-network
+    # AWS region where the Security Group should exist.
+    region: ap-southeast-1

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - xrd.yaml
+  - composition.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/xrd.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-platform-aws-security-group/xrd.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xsharedsecuritygroups.platform.aws.goodnotes.io
+spec:
+  group: platform.aws.goodnotes.io
+  names:
+    kind: XSharedSecurityGroup
+    plural: xsharedsecuritygroups
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  required:
+                    - boundaryClass
+                    - networkRef
+                    - region
+                  properties:
+                    boundaryClass:
+                      type: string
+                      description: Intent-level classification for this shared security boundary.
+                      enum:
+                        - control-plane
+                        - data-plane
+                        - internal-services
+                    description:
+                      type: string
+                      description: Optional AWS security group description.
+                      maxLength: 255
+                    deletionPolicy:
+                      type: string
+                      description: Crossplane deletion policy for the managed AWS resource.
+                      enum:
+                        - Delete
+                        - Orphan
+                    networkRef:
+                      type: object
+                      description: Reference to the owner-managed network boundary, not a raw VPC ID.
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    providerConfigRef:
+                      type: object
+                      description: Optional Crossplane AWS provider config override.
+                      properties:
+                        name:
+                          type: string
+                    region:
+                      type: string
+                      description: AWS region for the shared security group.
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                arn:
+                  type: string
+                securityGroupId:
+                  type: string
+                vpcId:
+                  type: string

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/README.md
@@ -1,0 +1,114 @@
+## Goal
+
+Install a Crossplane AWS provider into the existing `kind-goodnotes-k8s-demo` management cluster so Crossplane can reconcile AWS managed resources.
+
+This stack follows the Crossplane v2 provider model:
+
+- `provider-aws-ec2` installs VPC, subnet, route table, security group, NAT, and instance style primitives.
+- `provider-aws-eks` installs EKS cluster, node group, addon, and identity APIs.
+- `provider-aws-iam` installs IAM users, roles, policies, and attachments.
+- `provider-aws-rds` installs RDS instance and cluster APIs.
+- `provider-aws-s3` installs S3 bucket and bucket-adjacent APIs.
+- Crossplane automatically installs `provider-family-aws` as a dependency for shared AWS authentication.
+- `provider-config/` creates `ClusterProviderConfig/default`, which points AWS managed resources at a secret named `aws-secret` in `crossplane-system`.
+
+## 1. Prerequisites
+
+Crossplane core must already be installed:
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/namespaces
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane
+```
+
+Prepare an AWS credentials file in standard INI format:
+
+```ini
+[default]
+aws_access_key_id = REPLACE_ME
+aws_secret_access_key = REPLACE_ME
+```
+
+## 2. Create the AWS credentials secret
+
+```sh
+kubectl -n crossplane-system create secret generic aws-secret \
+  --from-file=creds=./aws-credentials.ini \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## 3. Install the provider
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-provider-aws
+```
+
+## 4. Wait until the provider is healthy
+
+```sh
+kubectl get providers
+
+kubectl wait \
+  --for=condition=Healthy \
+  provider.pkg.crossplane.io/crossplane-contrib-provider-aws-s3 \
+  --timeout=300s
+
+kubectl wait \
+  --for=condition=Healthy \
+  provider.pkg.crossplane.io/crossplane-contrib-provider-aws-ec2 \
+  --timeout=300s
+
+kubectl wait \
+  --for=condition=Healthy \
+  provider.pkg.crossplane.io/crossplane-contrib-provider-aws-iam \
+  --timeout=300s
+
+kubectl wait \
+  --for=condition=Healthy \
+  provider.pkg.crossplane.io/crossplane-contrib-provider-aws-rds \
+  --timeout=300s
+
+kubectl wait \
+  --for=condition=Healthy \
+  provider.pkg.crossplane.io/crossplane-contrib-provider-aws-eks \
+  --timeout=300s
+```
+
+Expected outcome after the wait:
+
+- `crossplane-contrib-provider-aws-s3`, `-ec2`, `-iam`, `-rds`, and `-eks` become `HEALTHY=True`
+- `crossplane-contrib-provider-family-aws` appears automatically as a dependency
+
+## 5. Apply the cluster-wide AWS provider config
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-config
+kubectl get clusterproviderconfig.aws.m.upbound.io default
+```
+
+## 6. Create a demo AWS resource
+
+An example S3 bucket managed resource is provided under `examples/s3-bucket/`:
+
+Before applying it, edit `examples/s3-bucket/bucket.yaml` and replace
+`crossplane.io/external-name: replace-with-a-globally-unique-s3-bucket-name`
+with a globally unique S3 bucket name.
+
+```sh
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket
+kubectl get buckets.s3.aws.m.upbound.io -n default
+```
+
+Delete it with:
+
+```sh
+kubectl delete -k kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket
+```
+
+## Notes
+
+- This root does not create AWS resources by default. It installs the provider and the cluster-wide AWS credential reference only.
+- Crossplane v2 packages AWS support by service. This repo now pre-installs the common base set for platform work: `ec2`, `eks`, `iam`, `rds`, and `s3`.
+- The Upbound provider packages in this repo use the official `xpkg.upbound.io/upbound/...` registry path.
+- The package versions are pinned per service provider. At the time this was updated, the current marketplace versions used here were `v2.5.3` for `ec2`, `eks`, `iam`, `rds`, and `s3`.
+- Do not uninstall the provider before deleting managed resources, or AWS resources may be left behind.

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket/bucket.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket/bucket.yaml
@@ -1,0 +1,10 @@
+apiVersion: s3.aws.m.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  namespace: default
+  name: crossplane-bucket-demo
+  annotations:
+    crossplane.io/external-name: replace-with-a-globally-unique-s3-bucket-name
+spec:
+  forProvider:
+    region: us-east-2

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/examples/s3-bucket/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - bucket.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - provider-aws-ec2.yaml
+  - provider-aws-eks.yaml
+  - provider-aws-iam.yaml
+  - provider-aws-rds.yaml
+  - provider-aws-s3.yaml

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-ec2.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-ec2.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-ec2
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:v2.5.3

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-eks.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-eks.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-eks
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-eks:v2.5.3

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-iam.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-iam.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-iam
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.5.3

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-rds.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-rds.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-rds
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-rds:v2.5.3

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-s3.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-aws-s3.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-contrib-provider-aws-s3
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v2.5.3

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-config/cluster-provider-config.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-config/cluster-provider-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ClusterProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-secret
+      key: creds

--- a/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-config/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane-provider-aws/provider-config/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - cluster-provider-config.yaml

--- a/kind-goodnotes-k8s-demo/crossplane/README.md
+++ b/kind-goodnotes-k8s-demo/crossplane/README.md
@@ -1,0 +1,26 @@
+## Installation
+
+```sh
+helm repo add crossplane-stable https://charts.crossplane.io/stable
+
+helm template crossplane crossplane-stable/crossplane \
+  --version 2.2.1 \
+  --namespace crossplane-system \
+  --include-crds \
+  -f values.yaml > manifest.yaml
+
+kubectl apply -k kind-goodnotes-k8s-demo/namespaces
+kubectl apply -k kind-goodnotes-k8s-demo/crossplane
+```
+
+## Verification
+
+```sh
+kubectl -n crossplane-system get pods
+kubectl get crds | rg crossplane
+```
+
+## Notes
+
+- `manifest.yaml` is rendered from the official Crossplane Helm chart and checked in for reproducible `kubectl diff -k` workflows.
+- This baseline installs only Crossplane core. Providers, Functions, and Configurations should be layered on top as separate packages once the control plane is healthy.

--- a/kind-goodnotes-k8s-demo/crossplane/kustomization.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kind-goodnotes-k8s-demo/crossplane/manifest.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane/manifest.yaml
@@ -1,0 +1,1005 @@
+---
+# Source: crossplane/templates/rbac-manager-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbac-manager
+  namespace: crossplane-system
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+automountServiceAccountToken: true
+---
+# Source: crossplane/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane
+  namespace: crossplane-system
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+automountServiceAccountToken: true
+---
+# Source: crossplane/templates/secret.yaml
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-root-ca
+  namespace: crossplane-system
+type: Opaque
+---
+# Source: crossplane/templates/secret.yaml
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-server
+  namespace: crossplane-system
+type: Opaque
+---
+# Source: crossplane/templates/secret.yaml
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-client
+  namespace: crossplane-system
+type: Opaque
+---
+# Source: crossplane/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-crossplane: "true"
+---
+# Source: crossplane/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:system:aggregate-to-crossplane
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+    crossplane.io/scope: "system"
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.crossplane.io
+  - ops.crossplane.io
+  - pkg.crossplane.io
+  - protection.crossplane.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+---
+# Source: crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:allowed-provider-permissions
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-allowed-provider-permissions: "true"
+---
+# Source: crossplane/templates/rbac-manager-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-rbac-manager
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - get
+    - list
+    - watch
+# The RBAC manager creates a series of RBAC roles for each namespace it sees.
+# These RBAC roles are controlled (in the owner reference sense) by the namespace.
+# The RBAC manager needs permission to set finalizers on Namespaces in order to
+# create resources that block their deletion when the
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources:
+  - compositeresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+# The RBAC manager creates a series of RBAC cluster roles for each XRD it sees.
+# These cluster roles are controlled (in the owner reference sense) by the XRD.
+# The RBAC manager needs permission to set finalizers on XRDs in order to
+# create resources that block their deletion when the 
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources:
+  - compositeresourcedefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - providerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+# The RBAC manager creates a series of RBAC cluster roles for each ProviderRevision
+# it sees. These cluster roles are controlled (in the owner reference sense) by the
+# ProviderRevision. The RBAC manager needs permission to set finalizers on
+# ProviderRevisions in order to create resources that block their deletion when the 
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - providerrevisions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  # The RBAC manager may grant access it does not have.
+  - escalate
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-admin
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-admin: "true"
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-edit
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-edit: "true"
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-view
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-view: "true"
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-browse
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-browse: "true"
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:aggregate-to-admin
+  labels:
+    rbac.crossplane.io/aggregate-to-admin: "true"
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+rules:
+# Crossplane administrators have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane administrators must create provider credential secrets, and may
+# need to read or otherwise interact with connection secrets. They may also need
+# to create or annotate namespaces.
+- apiGroups: [""]
+  resources: [secrets, namespaces]
+  verbs: ["*"]
+# Crossplane administrators have access to view the roles that they may be able
+# to grant to other subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterroles, roles]
+  verbs: [get, list, watch]
+# Crossplane administrators have access to grant the access they have to other
+# subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterrolebindings, rolebindings]
+  verbs: ["*"]
+# Crossplane administrators have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+# Crossplane administrators have access to view CRDs in order to debug XRDs.
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, watch]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+    - ops.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:aggregate-to-edit
+  labels:
+    rbac.crossplane.io/aggregate-to-edit: "true"
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+rules:
+# Crossplane editors have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane editors must create provider credential secrets, and may need to
+# read or otherwise interact with connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+# Crossplane editors may see which namespaces exist, but not edit them.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane editors have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+    - ops.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:aggregate-to-view
+  labels:
+    rbac.crossplane.io/aggregate-to-view: "true"
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+rules:
+# Crossplane viewers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane viewers may see which namespaces exist.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane viewers have read-only access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+    - ops.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:aggregate-to-browse
+  labels:
+    rbac.crossplane.io/aggregate-to-browse: "true"
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+rules:
+# Crossplane browsers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane browsers have read-only access to compositions and XRDs. This
+# allows them to discover and select an appropriate composition when creating a
+# resource claim.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+---
+# Source: crossplane/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane
+subjects:
+- kind: ServiceAccount
+  name: crossplane
+  namespace: crossplane-system
+---
+# Source: crossplane/templates/rbac-manager-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-rbac-manager
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-rbac-manager
+subjects:
+- kind: ServiceAccount
+  name: rbac-manager
+  namespace: crossplane-system
+---
+# Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-admin
+  labels:
+    app: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: crossplane:masters
+---
+# Source: crossplane/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: crossplane-webhooks
+  namespace: crossplane-system
+  labels:
+    app: crossplane
+    release: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+  annotations:
+spec:
+  selector:
+    app: crossplane
+    release: crossplane
+  ports:
+  - protocol: TCP
+    port: 9443
+    targetPort: 9443
+---
+# Source: crossplane/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane
+  namespace: crossplane-system
+  labels:
+    app: crossplane
+    release: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crossplane
+      release: crossplane
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: crossplane
+        release: crossplane        
+        helm.sh/chart: crossplane-2.2.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: cloud-infrastructure-controller
+        app.kubernetes.io/part-of: crossplane
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/instance: crossplane
+        app.kubernetes.io/version: "2.2.1"
+    spec:
+      serviceAccountName: crossplane
+      hostNetwork: false
+      initContainers:
+        - name: crossplane-init
+          image: "xpkg.crossplane.io/crossplane/crossplane:v2.2.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - core
+          - init
+          - --activation
+          - "*"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+          env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane-init
+                resource: limits.cpu
+                divisor: "1"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane-init
+                resource: limits.memory
+                divisor: "1"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: "WEBHOOK_SERVICE_NAME"
+            value: crossplane-webhooks
+          - name: "WEBHOOK_SERVICE_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "WEBHOOK_SERVICE_PORT"
+            value: "9443"
+          - name: "TLS_CA_SECRET_NAME"
+            value: crossplane-root-ca
+          - name: "TLS_SERVER_SECRET_NAME"
+            value: crossplane-tls-server
+          - name: "TLS_CLIENT_SECRET_NAME"
+            value: crossplane-tls-client
+      containers:
+      - name: crossplane
+        image: "xpkg.crossplane.io/crossplane/crossplane:v2.2.1"
+        args:
+        - core
+        - start
+        imagePullPolicy: IfNotPresent
+        resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 2
+          tcpSocket:
+            port: readyz
+        ports:
+        - name: readyz
+          containerPort: 8081
+        - name: metrics
+          containerPort: 8080
+        - name: webhooks
+          containerPort: 9443
+        securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane
+                resource: limits.cpu
+                divisor: "1"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane
+                resource: limits.memory
+                divisor: "1"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: LEADER_ELECTION
+            value: "true"
+          - name: "TLS_SERVER_SECRET_NAME"
+            value: crossplane-tls-server
+          - name: "TLS_SERVER_CERTS_DIR"
+            value: /tls/server
+          - name: "TLS_CLIENT_SECRET_NAME"
+            value: crossplane-tls-client
+          - name: "TLS_CLIENT_CERTS_DIR"
+            value: /tls/client
+        volumeMounts:
+          - mountPath: /cache/xpkg
+            name: package-cache
+          - mountPath: /cache/xfn
+            name: function-cache
+          - mountPath: /tls/server
+            name: tls-server-certs
+          - mountPath: /tls/client
+            name: tls-client-certs
+      volumes:
+      - name: package-cache
+        emptyDir:
+          medium: 
+          sizeLimit: 20Mi
+      - name: function-cache
+        emptyDir:
+          medium: 
+          sizeLimit: 512Mi
+      - name: tls-server-certs
+        secret:
+          secretName: crossplane-tls-server
+      - name: tls-client-certs
+        secret:
+          secretName: crossplane-tls-client
+---
+# Source: crossplane/templates/rbac-manager-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane-rbac-manager
+  namespace: crossplane-system
+  labels:
+    app: crossplane-rbac-manager
+    release: crossplane    
+    helm.sh/chart: crossplane-2.2.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/version: "2.2.1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crossplane-rbac-manager
+      release: crossplane
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: crossplane-rbac-manager
+        release: crossplane        
+        helm.sh/chart: crossplane-2.2.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: cloud-infrastructure-controller
+        app.kubernetes.io/part-of: crossplane
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/instance: crossplane
+        app.kubernetes.io/version: "2.2.1"
+    spec:
+      serviceAccountName: rbac-manager
+      initContainers:
+      - name: crossplane-init
+        image: "xpkg.crossplane.io/crossplane/crossplane:v2.2.1"
+        args:
+        - rbac
+        - init
+        imagePullPolicy: IfNotPresent
+        resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+        securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane-init
+                resource: limits.cpu
+                divisor: "1"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane-init
+                resource: limits.memory
+                divisor: "1"
+      containers:
+      - name: crossplane
+        image: "xpkg.crossplane.io/crossplane/crossplane:v2.2.1"
+        args:
+        - rbac
+        - start
+        - --provider-clusterrole=crossplane:allowed-provider-permissions
+        imagePullPolicy: IfNotPresent
+        resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+        ports:
+        - name: metrics
+          containerPort: 8080
+        securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane
+                resource: limits.cpu
+                divisor: "1"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: crossplane
+                resource: limits.memory
+                divisor: "1"
+          - name: LEADER_ELECTION
+            value: "true"

--- a/kind-goodnotes-k8s-demo/crossplane/values.yaml
+++ b/kind-goodnotes-k8s-demo/crossplane/values.yaml
@@ -1,0 +1,7 @@
+replicas: 1
+
+metrics:
+  enabled: true
+
+rbacManager:
+  replicas: 1

--- a/kind-goodnotes-k8s-demo/namespaces/namespaces.yaml
+++ b/kind-goodnotes-k8s-demo/namespaces/namespaces.yaml
@@ -57,6 +57,14 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: crossplane-system
+  labels:
+    namespace: crossplane-system
+    kubernetes.io/metadata.name: crossplane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: gateway
   labels:
     namespace: gateway


### PR DESCRIPTION
## Summary

This PR mainly expands the repo from a local Kubernetes demo into a broader platform-engineering playground with Crossplane, managed-cluster patterns, and stronger observability/storage documentation.

### Main changes
- Added a new Crossplane control-plane stack under `kind-goodnotes-k8s-demo/crossplane`, including namespace registration and installation docs.
- Added AWS provider packaging for Crossplane (`ec2`, `eks`, `iam`, `rds`, `s3`) plus a default `ClusterProviderConfig`.
- Introduced two owner-style Crossplane platform APIs:
  - `XNetwork` for VPC/network topology ownership
  - `XSharedSecurityGroup` for shared security-boundary ownership
- Added a managed Kind child-cluster example using Crossplane `provider-kubernetes` and `provider-helm`.
- Aligned MinIO manifests from standalone chart output to MinIO Operator `Tenant` resources used by the local monitoring stack.
- Updated Loki and OTel manifests to better match the live observability runtime:
  - Loki retention/compactor settings enabled
  - OTel RBAC expanded for richer k8s metadata enrichment
- Added k6 `TestRun` manifests for `foo` and `bar` smoke/soak validation.
- Added operational docs and RCA notes for observability, storage governance, and network-policy mapping.

### Modified existing files
- `README.md`: expanded repo scope and install/runtime documentation to include Crossplane.
- `namespaces.yaml`: added `crossplane-system`.

### Notes
- This branch currently also contains several local scratch/debug artifacts and documentation drafts.
- Before opening the PR, it would be worth filtering out generated diff logs, local credentials, and unrelated personal notes.